### PR TITLE
Add AIX compatibility

### DIFF
--- a/.github/workflows/cfarm-ssh-tests.yml
+++ b/.github/workflows/cfarm-ssh-tests.yml
@@ -1,0 +1,136 @@
+name: Compile Farm SSH Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cfarm-ssh-test:
+    name: ${{ matrix.name }} (${{ matrix.host }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: aix
+            host: cfarm119.cfarm.net
+            host_key: cfarm119.cfarm.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB3/qHMdOGpZ8DD5E8J7falo8IDJ962oGsgSycuHXXRO
+            cc: /opt/freeware/bin/gcc
+            shell: /opt/freeware/bin/bash
+            path: /opt/freeware/bin:/usr/bin:/bin
+            test_script: test/simple.test.sh
+
+    concurrency:
+      group: cfarm-${{ matrix.host }}
+      cancel-in-progress: false
+
+    env:
+      CFARM_NAME: ${{ matrix.name }}
+      CFARM_HOST: ${{ matrix.host }}
+      CFARM_HOST_KEY: ${{ matrix.host_key }}
+      CFARM_CC: ${{ matrix.cc }}
+      CFARM_SHELL: ${{ matrix.shell }}
+      CFARM_PATH: ${{ matrix.path }}
+      CFARM_TEST_SCRIPT: ${{ matrix.test_script }}
+      CFARM_USER: ${{ secrets.CFARM_USER }}
+      CFARM_SSH_KEY: ${{ secrets.CFARM_SSH_KEY }}
+      IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Check compile farm SSH secrets
+        id: cfarm-secrets
+        shell: bash
+        run: |
+          if [[ -z "$CFARM_USER" || -z "$CFARM_SSH_KEY" ]]; then
+            if [[ "$IS_FORK_PR" != "true" ]]; then
+              echo "::error::CFARM_USER and CFARM_SSH_KEY secrets are required for compile farm SSH tests."
+              exit 1
+            fi
+
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "Compile farm SSH secrets are not available to forked pull requests; skipping compile farm test."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure SSH
+        id: configure-ssh
+        if: steps.cfarm-secrets.outputs.available == 'true'
+        shell: bash
+        run: |
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$CFARM_SSH_KEY" > ~/.ssh/cfarm_ci_key
+          chmod 600 ~/.ssh/cfarm_ci_key
+          printf '%s\n' "$CFARM_HOST_KEY" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+          cat > ~/.ssh/config <<EOF
+          Host cfarm-ci
+            HostName $CFARM_HOST
+            HostKeyAlias $CFARM_HOST
+            User $CFARM_USER
+            IdentityFile ~/.ssh/cfarm_ci_key
+            IdentitiesOnly yes
+            StrictHostKeyChecking yes
+            UserKnownHostsFile ~/.ssh/known_hosts
+            BatchMode yes
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Prepare remote workspace
+        id: remote-workspace
+        if: steps.cfarm-secrets.outputs.available == 'true'
+        shell: bash
+        run: |
+          remote_home="$(ssh cfarm-ci 'printf "%s" "$HOME"')"
+          run_date="$(date -u +%Y-%m-%dT%H%M%SZ)"
+          remote_work="$remote_home/eatmemory-ci/runs/${run_date}-${CFARM_NAME}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+          echo "path=$remote_work" >> "$GITHUB_OUTPUT"
+          echo "REMOTE_WORK=$remote_work" >> "$GITHUB_ENV"
+
+          ssh cfarm-ci "REMOTE_WORK=$remote_work /usr/bin/ksh -s" <<'EOF'
+          set -eu
+
+          base="$HOME/eatmemory-ci/runs"
+          /usr/bin/mkdir -p "$base"
+          /usr/bin/chmod 700 "$HOME/eatmemory-ci" "$base"
+
+          for path in "$base"/*; do
+            if [ -d "$path" ]; then
+              /usr/bin/find "$path" -prune -type d -mtime +7 -exec /usr/bin/rm -rf {} \;
+            fi
+          done
+
+          /usr/bin/mkdir -p "$REMOTE_WORK"
+          /usr/bin/chmod 700 "$REMOTE_WORK"
+          EOF
+
+      - name: Copy source to compile farm host
+        if: steps.cfarm-secrets.outputs.available == 'true'
+        shell: bash
+        run: |
+          git archive --format=tar HEAD | ssh cfarm-ci "cd \"$REMOTE_WORK\" && /usr/bin/tar -xf -"
+
+      - name: Build and test on compile farm host
+        if: steps.cfarm-secrets.outputs.available == 'true'
+        shell: bash
+        run: |
+          ssh cfarm-ci "cd \"$REMOTE_WORK\" && PATH=\"$CFARM_PATH\" CC=\"$CFARM_CC\" \"$CFARM_SHELL\" \"$CFARM_TEST_SCRIPT\""
+
+      - name: Clean remote workspace
+        if: always() && steps.cfarm-secrets.outputs.available == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          if [[ -n "${REMOTE_WORK:-}" ]]; then
+            ssh cfarm-ci "/usr/bin/rm -rf \"$REMOTE_WORK\""
+          fi

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ EXTRA_CFLAGS ?=
 CFLAGS := -Wall -Wextra -std=c99 -O2 -g $(EXTRA_CFLAGS) -DVERSION='"$(VERSION)"'
 LDFLAGS :=
 
+UNAME_S := $(shell uname -s 2>/dev/null)
+ifeq ($(UNAME_S),AIX)
+    LDFLAGS += -lperfstat
+endif
+
 ifneq ($(findstring mingw,$(CC)),)
     EXE_SUFFIX := .exe
 else
@@ -64,7 +69,6 @@ help:
 	@echo "  help          - Display this help message"
 
 .PHONY: all install clean help
-
 
 
 

--- a/src/args.c
+++ b/src/args.c
@@ -131,7 +131,7 @@ static Vec* vec_new() {
 }
 
 
-static void vec_free(Vec* vec) {
+static void vec_destroy(Vec* vec) {
     if (vec) {
         free(vec->entries);
         free(vec);
@@ -715,7 +715,7 @@ void ap_free(ArgParser* parser) {
         for (int i = 0; i < parser->option_vec->count; i++) {
             option_free(parser->option_vec->entries[i]);
         }
-        vec_free(parser->option_vec);
+        vec_destroy(parser->option_vec);
     }
 
     if (parser->command_map) {
@@ -726,11 +726,11 @@ void ap_free(ArgParser* parser) {
         for (int i = 0; i < parser->command_vec->count; i++) {
             ap_free(parser->command_vec->entries[i]);
         }
-        vec_free(parser->command_vec);
+        vec_destroy(parser->command_vec);
     }
 
     if (parser->positional_args) {
-        vec_free(parser->positional_args);
+        vec_destroy(parser->positional_args);
     }
 
     free(parser);

--- a/src/eatmemory.aix.c
+++ b/src/eatmemory.aix.c
@@ -2,6 +2,9 @@
 #ifdef SYSMEM_MODE_AIX
 #include <libperfstat.h>
 
+/* libperfstat always reports real_total/real_free in 4 KB units regardless
+ * of the system page size (e.g. 64 KB large pages); do not replace with
+ * sysconf(_SC_PAGE_SIZE). See IBM perfstat_memory_total_t documentation. */
 #define AIX_PERFSTAT_PAGE_SIZE 4096ULL
 
 static size_t pages_4k_to_bytes_clamped(u_longlong_t pages) {

--- a/src/eatmemory.aix.c
+++ b/src/eatmemory.aix.c
@@ -1,0 +1,31 @@
+#include "eatmemory.h"
+#ifdef SYSMEM_MODE_AIX
+#include <libperfstat.h>
+
+#define AIX_PERFSTAT_PAGE_SIZE 4096ULL
+
+static size_t pages_4k_to_bytes_clamped(u_longlong_t pages) {
+    if (pages > (u_longlong_t)(SIZE_MAX / AIX_PERFSTAT_PAGE_SIZE)) {
+        return SIZE_MAX;
+    }
+
+    return (size_t)(pages * AIX_PERFSTAT_PAGE_SIZE);
+}
+
+void get_system_memory_stats(struct system_memory_stats* stats) {
+    stats->supported = false;
+    stats->total = 0;
+    stats->free = 0;
+
+    perfstat_memory_total_t memory;
+    int count = perfstat_memory_total(NULL, &memory, sizeof(memory), 1);
+    if (count != 1) {
+        return;
+    }
+
+    stats->total = pages_4k_to_bytes_clamped(memory.real_total);
+    stats->free = pages_4k_to_bytes_clamped(memory.real_free);
+    stats->supported = true;
+}
+
+#endif

--- a/src/eatmemory.h
+++ b/src/eatmemory.h
@@ -14,6 +14,8 @@
     #define SYSMEM_MODE_APPLE
 #elif defined(_WIN32) || defined(_WIN64)
     #define SYSMEM_MODE_WINDOWS
+#elif defined(_AIX)
+    #define SYSMEM_MODE_AIX
 #elif defined(__linux__)
     #define SYSMEM_MODE_LINUX
 #else


### PR DESCRIPTION
## Summary
- avoid AIX vec_free macro collision by renaming the internal vector cleanup helper
- add AIX memory stats via libperfstat and link with -lperfstat on AIX
- add a pull-request compile farm SSH workflow using CFARM_* secrets and a per-host matrix

## Testing
- local make
- AIX clean build on cfarm119.cfarm.net with /opt/freeware/bin/gcc
- AIX test/simple.test.sh with CC=/opt/freeware/bin/gcc
- manually exercised the compile farm workflow transfer/build/test/cleanup flow on cfarm119.cfarm.net

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AIX platform support to report system memory statistics
  * Added CI workflow to run compile-farm SSH tests for AIX

* **Bug Fixes / Refactor**
  * Parser vector cleanup unified under a dedicated destructor for improved stability

* **Chores**
  * Build adjusted to link the AIX performance library when running on AIX

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/julman99/eatmemory/pull/19)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->