### PR TITLE
Add Solaris memory stats support

### DIFF
--- a/.github/workflows/cfarm-ssh-tests.yml
+++ b/.github/workflows/cfarm-ssh-tests.yml
@@ -21,6 +21,7 @@ jobs:
             host: cfarm119.cfarm.net
             host_key: cfarm119.cfarm.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB3/qHMdOGpZ8DD5E8J7falo8IDJ962oGsgSycuHXXRO
             cc: /opt/freeware/bin/gcc
+            make: /opt/freeware/bin/make
             extra_cflags: ""
             shell: /opt/freeware/bin/bash
             path: /opt/freeware/bin:/usr/bin:/bin
@@ -29,9 +30,28 @@ jobs:
             host: cfarm119.cfarm.net
             host_key: cfarm119.cfarm.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB3/qHMdOGpZ8DD5E8J7falo8IDJ962oGsgSycuHXXRO
             cc: /opt/freeware/bin/gcc
+            make: /opt/freeware/bin/make
             extra_cflags: -maix64
             shell: /opt/freeware/bin/bash
             path: /opt/freeware/bin:/usr/bin:/bin
+            test_script: test/simple.test.sh
+          - name: solaris-64
+            host: cfarm215.cfarm.net
+            host_key: cfarm215.cfarm.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHaWRY0hu3p8Nf8NOHQY4rNT5Ph+M5uL+Hjl0fnROCZv
+            cc: /usr/bin/gcc
+            make: /usr/bin/gmake
+            extra_cflags: -m64
+            shell: /usr/bin/bash
+            path: /usr/bin:/bin:/usr/sbin:/sbin
+            test_script: test/simple.test.sh
+          - name: solaris-32
+            host: cfarm215.cfarm.net
+            host_key: cfarm215.cfarm.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHaWRY0hu3p8Nf8NOHQY4rNT5Ph+M5uL+Hjl0fnROCZv
+            cc: /usr/bin/gcc
+            make: /usr/bin/gmake
+            extra_cflags: -m32
+            shell: /usr/bin/bash
+            path: /usr/bin:/bin:/usr/sbin:/sbin
             test_script: test/simple.test.sh
 
     concurrency:
@@ -43,6 +63,7 @@ jobs:
       CFARM_HOST: ${{ matrix.host }}
       CFARM_HOST_KEY: ${{ matrix.host_key }}
       CFARM_CC: ${{ matrix.cc }}
+      CFARM_MAKE: ${{ matrix.make }}
       CFARM_EXTRA_CFLAGS: ${{ matrix.extra_cflags }}
       CFARM_SHELL: ${{ matrix.shell }}
       CFARM_PATH: ${{ matrix.path }}
@@ -128,13 +149,13 @@ jobs:
         if: steps.cfarm-secrets.outputs.available == 'true'
         shell: bash
         run: |
-          git archive --format=tar HEAD | ssh cfarm-ci "cd \"$REMOTE_WORK\" && /usr/bin/tar -xf -"
+          tar --format=ustar --exclude .git --exclude output --exclude .DS_Store -cf - . | ssh cfarm-ci "cd \"$REMOTE_WORK\" && /usr/bin/tar -xf -"
 
       - name: Build and test on compile farm host
         if: steps.cfarm-secrets.outputs.available == 'true'
         shell: bash
         run: |
-          ssh cfarm-ci "cd \"$REMOTE_WORK\" && PATH=\"$CFARM_PATH\" CC=\"$CFARM_CC\" EXTRA_CFLAGS=\"$CFARM_EXTRA_CFLAGS\" \"$CFARM_SHELL\" \"$CFARM_TEST_SCRIPT\""
+          ssh cfarm-ci "cd \"$REMOTE_WORK\" && PATH=\"$CFARM_PATH\" CC=\"$CFARM_CC\" MAKE=\"$CFARM_MAKE\" EXTRA_CFLAGS=\"$CFARM_EXTRA_CFLAGS\" \"$CFARM_SHELL\" \"$CFARM_TEST_SCRIPT\""
 
       - name: Clean remote workspace
         if: always() && steps.cfarm-secrets.outputs.available == 'true'

--- a/src/eatmemory.h
+++ b/src/eatmemory.h
@@ -16,6 +16,8 @@
     #define SYSMEM_MODE_WINDOWS
 #elif defined(_AIX)
     #define SYSMEM_MODE_AIX
+#elif defined(__sun)
+    #define SYSMEM_MODE_SOLARIS
 #elif defined(__linux__)
     #define SYSMEM_MODE_LINUX
 #else

--- a/src/eatmemory.solaris.c
+++ b/src/eatmemory.solaris.c
@@ -17,7 +17,7 @@ void get_system_memory_stats(struct system_memory_stats* stats) {
     long page_size = sysconf(_SC_PAGE_SIZE);
     long free_pages = sysconf(_SC_AVPHYS_PAGES);
 
-    if (pages > 0 && page_size > 0 && free_pages > 0) {
+    if (pages > 0 && page_size > 0 && free_pages >= 0) {
         stats->total = pages_to_bytes_clamped(pages, page_size);
         stats->free = pages_to_bytes_clamped(free_pages, page_size);
         stats->supported = true;

--- a/src/eatmemory.solaris.c
+++ b/src/eatmemory.solaris.c
@@ -1,0 +1,28 @@
+#include "eatmemory.h"
+#ifdef SYSMEM_MODE_SOLARIS
+#include <unistd.h>
+
+static size_t pages_to_bytes_clamped(long pages, long page_size) {
+    uint64_t bytes = (uint64_t)pages * (uint64_t)page_size;
+    return bytes > SIZE_MAX ? SIZE_MAX : (size_t)bytes;
+}
+
+void get_system_memory_stats(struct system_memory_stats* stats) {
+    stats->supported = false;
+    stats->total = 0;
+    stats->free = 0;
+
+#if defined(_SC_PHYS_PAGES) && defined(_SC_AVPHYS_PAGES) && defined(_SC_PAGE_SIZE)
+    long pages = sysconf(_SC_PHYS_PAGES);
+    long page_size = sysconf(_SC_PAGE_SIZE);
+    long free_pages = sysconf(_SC_AVPHYS_PAGES);
+
+    if (pages > 0 && page_size > 0 && free_pages > 0) {
+        stats->total = pages_to_bytes_clamped(pages, page_size);
+        stats->free = pages_to_bytes_clamped(free_pages, page_size);
+        stats->supported = true;
+    }
+#endif
+}
+
+#endif

--- a/test/simple.test.sh
+++ b/test/simple.test.sh
@@ -27,10 +27,10 @@ echo "Changing to project directory..."
 cd "$PROJECT_ROOT"
 
 echo "Cleaning previous build..."
-make clean
+"${MAKE:-make}" clean
 
 echo "Building eatmemory..."
-make
+"${MAKE:-make}"
 
 echo "Checking if eatmemory executable exists..."
 if [[ ! -f "output/eatmemory" ]]; then


### PR DESCRIPTION
## Summary
- add Solaris platform detection and a sysconf-based memory stats backend
- add Solaris 64-bit and 32-bit compile-farm jobs on cfarm215
- let test/simple.test.sh honor MAKE so Solaris can use gmake
- use a portable ustar source stream for compile-farm transfers because Solaris tar rejects git archive pax headers

## Testing
- local MAKE=make bash test/simple.test.sh
- Solaris 64-bit on cfarm215: CC=/usr/bin/gcc MAKE=/usr/bin/gmake EXTRA_CFLAGS=-m64 /usr/bin/bash test/simple.test.sh
- Solaris 32-bit on cfarm215: CC=/usr/bin/gcc MAKE=/usr/bin/gmake EXTRA_CFLAGS=-m32 /usr/bin/bash test/simple.test.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Solaris support with system memory reporting.

* **Chores**
  * Improved CI/workflow and source transfer for better AIX and Solaris cross-platform builds.
  * Standardized build tool configuration across platforms.

* **Tests**
  * Test/build scripts updated to honor the configured build tool during clean and build phases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/julman99/eatmemory/pull/21)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->