### PR TITLE
Add BSD memory stats support

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,9 +1,8 @@
 name: Docker Build Test
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ main, master, v* ]
-  pull_request:
     branches: [ main, master, v* ]
 
 concurrency:

--- a/.github/workflows/cfarm-ssh-tests.yml
+++ b/.github/workflows/cfarm-ssh-tests.yml
@@ -17,41 +17,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: aix
-            host: cfarm119.cfarm.net
-            host_key: cfarm119.cfarm.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB3/qHMdOGpZ8DD5E8J7falo8IDJ962oGsgSycuHXXRO
-            cc: /opt/freeware/bin/gcc
-            make: /opt/freeware/bin/make
+          - name: freebsd
+            host: cfarm430.cfarm.net
+            port: 22430
+            host_key: cfarm430.cfarm.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIInfLqQ7/xsj/KZjLNwyzj5Lck2eqCZLvjZn771LPXFc
+            cc: /usr/bin/cc
+            make: /usr/local/bin/gmake
+            tar: /usr/bin/tar
+            kex_algorithms: curve25519-sha256
             extra_cflags: ""
-            shell: /opt/freeware/bin/bash
-            path: /opt/freeware/bin:/usr/bin:/bin
-            test_script: test/simple.test.sh
-          - name: aix-64
-            host: cfarm119.cfarm.net
-            host_key: cfarm119.cfarm.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB3/qHMdOGpZ8DD5E8J7falo8IDJ962oGsgSycuHXXRO
-            cc: /opt/freeware/bin/gcc
-            make: /opt/freeware/bin/make
-            extra_cflags: -maix64
-            shell: /opt/freeware/bin/bash
-            path: /opt/freeware/bin:/usr/bin:/bin
-            test_script: test/simple.test.sh
-          - name: solaris-64
-            host: cfarm215.cfarm.net
-            host_key: cfarm215.cfarm.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHaWRY0hu3p8Nf8NOHQY4rNT5Ph+M5uL+Hjl0fnROCZv
-            cc: /usr/bin/gcc
-            make: /usr/bin/gmake
-            extra_cflags: -m64
-            shell: /usr/bin/bash
-            path: /usr/bin:/bin:/usr/sbin:/sbin
-            test_script: test/simple.test.sh
-          - name: solaris-32
-            host: cfarm215.cfarm.net
-            host_key: cfarm215.cfarm.net ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHaWRY0hu3p8Nf8NOHQY4rNT5Ph+M5uL+Hjl0fnROCZv
-            cc: /usr/bin/gcc
-            make: /usr/bin/gmake
-            extra_cflags: -m32
-            shell: /usr/bin/bash
-            path: /usr/bin:/bin:/usr/sbin:/sbin
+            shell: /usr/local/bin/bash
+            path: /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
             test_script: test/simple.test.sh
 
     concurrency:
@@ -61,9 +37,12 @@ jobs:
     env:
       CFARM_NAME: ${{ matrix.name }}
       CFARM_HOST: ${{ matrix.host }}
+      CFARM_PORT: ${{ matrix.port }}
       CFARM_HOST_KEY: ${{ matrix.host_key }}
       CFARM_CC: ${{ matrix.cc }}
       CFARM_MAKE: ${{ matrix.make }}
+      CFARM_TAR: ${{ matrix.tar }}
+      CFARM_KEX_ALGORITHMS: ${{ matrix.kex_algorithms || '' }}
       CFARM_EXTRA_CFLAGS: ${{ matrix.extra_cflags }}
       CFARM_SHELL: ${{ matrix.shell }}
       CFARM_PATH: ${{ matrix.path }}
@@ -71,6 +50,8 @@ jobs:
       CFARM_USER: ${{ secrets.CFARM_USER }}
       CFARM_SSH_KEY: ${{ secrets.CFARM_SSH_KEY }}
       IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+      SOURCE_REPO: https://github.com/${{ github.repository }}.git
+      SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
     steps:
       - name: Checkout code
@@ -106,6 +87,7 @@ jobs:
           cat > ~/.ssh/config <<EOF
           Host cfarm-ci
             HostName $CFARM_HOST
+            Port $CFARM_PORT
             HostKeyAlias $CFARM_HOST
             User $CFARM_USER
             IdentityFile ~/.ssh/cfarm_ci_key
@@ -114,54 +96,82 @@ jobs:
             UserKnownHostsFile ~/.ssh/known_hosts
             BatchMode yes
           EOF
+          if [[ -n "$CFARM_KEX_ALGORITHMS" ]]; then
+            printf '  KexAlgorithms %s\n' "$CFARM_KEX_ALGORITHMS" >> ~/.ssh/config
+          fi
           chmod 600 ~/.ssh/config
 
-      - name: Prepare remote workspace
+      - name: Diagnose FreeBSD SSH and remote git
         id: remote-workspace
         if: steps.cfarm-secrets.outputs.available == 'true'
         shell: bash
         run: |
-          remote_home="$(ssh cfarm-ci 'printf "%s" "$HOME"')"
+          set -u
+
           run_date="$(date -u +%Y-%m-%dT%H%M%SZ)"
-          remote_work="$remote_home/eatmemory-ci/runs/${run_date}-${CFARM_NAME}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          remote_work="eatmemory-ci/runs/${run_date}-${CFARM_NAME}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          remote_debug_log="eatmemory-ci/debug-${run_date}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.log"
 
           echo "path=$remote_work" >> "$GITHUB_OUTPUT"
           echo "REMOTE_WORK=$remote_work" >> "$GITHUB_ENV"
+          echo "REMOTE_DEBUG_LOG=$remote_debug_log" >> "$GITHUB_ENV"
 
-          ssh cfarm-ci "REMOTE_WORK=$remote_work /usr/bin/ksh -s" <<'EOF'
+          timestamp() {
+            date -u +"%Y-%m-%dT%H:%M:%SZ"
+          }
+
+          echo "$(timestamp) probe 1: ssh command"
+          timeout 45s ssh -vvv -T cfarm-ci 'printf "ssh-ok home=<%s> shell=<%s>\n" "$HOME" "$SHELL"; uname -a'
+
+          echo "$(timestamp) prepare remote workspace and watchdog"
+          timeout 45s ssh -T cfarm-ci "REMOTE_WORK=$remote_work REMOTE_DEBUG_LOG=$remote_debug_log PATH=\"$CFARM_PATH\" \"$CFARM_SHELL\" -s" <<'EOF'
           set -eu
-
           base="$HOME/eatmemory-ci/runs"
-          /usr/bin/mkdir -p "$base"
-          /usr/bin/chmod 700 "$HOME/eatmemory-ci" "$base"
-
+          mkdir -p "$base"
+          chmod 700 "$HOME/eatmemory-ci" "$base"
           for path in "$base"/*; do
             if [ -d "$path" ]; then
-              /usr/bin/find "$path" -prune -type d -mtime +7 -exec /usr/bin/rm -rf {} \;
+              find "$path" -prune -type d -mtime +7 -exec rm -rf {} \;
             fi
           done
-
-          /usr/bin/mkdir -p "$REMOTE_WORK"
-          /usr/bin/chmod 700 "$REMOTE_WORK"
+          rm -rf "$HOME/$REMOTE_WORK"
+          mkdir -p "$HOME/$REMOTE_WORK"
+          chmod 700 "$HOME/$REMOTE_WORK"
+          (
+            while :; do
+              date -u
+              ps -uxww | egrep 'ssh|scp|sftp|git|make|gmake|cc|tar|eatmemory-ci' | grep -v egrep || true
+              sleep 5
+            done
+          ) > "$HOME/$REMOTE_DEBUG_LOG" 2>&1 &
+          echo "$!" > "$HOME/$REMOTE_WORK/watchdog.pid"
           EOF
 
-      - name: Copy source to compile farm host
-        if: steps.cfarm-secrets.outputs.available == 'true'
-        shell: bash
-        run: |
-          tar --format=ustar --exclude .git --exclude output --exclude .DS_Store -cf - . | ssh cfarm-ci "cd \"$REMOTE_WORK\" && /usr/bin/tar -xf -"
+          echo "$(timestamp) probe 2: remote git fetch and test"
+          timeout 240s ssh -vvv -T cfarm-ci "REMOTE_WORK=$remote_work SOURCE_REPO=$SOURCE_REPO SOURCE_SHA=$SOURCE_SHA CFARM_CC=\"$CFARM_CC\" CFARM_MAKE=\"$CFARM_MAKE\" CFARM_EXTRA_CFLAGS=\"$CFARM_EXTRA_CFLAGS\" CFARM_SHELL=\"$CFARM_SHELL\" CFARM_TEST_SCRIPT=\"$CFARM_TEST_SCRIPT\" PATH=\"$CFARM_PATH\" \"$CFARM_SHELL\" -s" <<'EOF'
+          set -eux
+          cd "$HOME/$REMOTE_WORK"
+          git init
+          git remote add origin "$SOURCE_REPO"
+          git fetch --depth 1 origin "$SOURCE_SHA"
+          git -c advice.detachedHead=false checkout --detach FETCH_HEAD
+          CC="$CFARM_CC" MAKE="$CFARM_MAKE" EXTRA_CFLAGS="$CFARM_EXTRA_CFLAGS" "$CFARM_SHELL" "$CFARM_TEST_SCRIPT"
+          EOF
 
-      - name: Build and test on compile farm host
-        if: steps.cfarm-secrets.outputs.available == 'true'
-        shell: bash
-        run: |
-          ssh cfarm-ci "cd \"$REMOTE_WORK\" && PATH=\"$CFARM_PATH\" CC=\"$CFARM_CC\" MAKE=\"$CFARM_MAKE\" EXTRA_CFLAGS=\"$CFARM_EXTRA_CFLAGS\" \"$CFARM_SHELL\" \"$CFARM_TEST_SCRIPT\""
+          echo "$(timestamp) done diagnostics"
 
       - name: Clean remote workspace
         if: always() && steps.cfarm-secrets.outputs.available == 'true'
         continue-on-error: true
         shell: bash
         run: |
+          if [[ -n "${REMOTE_DEBUG_LOG:-}" ]]; then
+            echo "Remote debug log:"
+            timeout 20s ssh -T cfarm-ci "cat \"$REMOTE_DEBUG_LOG\" 2>/dev/null || true"
+          fi
           if [[ -n "${REMOTE_WORK:-}" ]]; then
-            ssh cfarm-ci "/usr/bin/rm -rf \"$REMOTE_WORK\""
+            timeout 20s ssh -T cfarm-ci "if [ -f \"$REMOTE_WORK/watchdog.pid\" ]; then kill \$(cat \"$REMOTE_WORK/watchdog.pid\") 2>/dev/null || true; fi; rm -rf \"$REMOTE_WORK\""
+          fi
+          if [[ -n "${REMOTE_DEBUG_LOG:-}" ]]; then
+            timeout 20s ssh -T cfarm-ci "rm -f \"$REMOTE_DEBUG_LOG\""
           fi

--- a/.github/workflows/dockcross-tests.yml
+++ b/.github/workflows/dockcross-tests.yml
@@ -1,9 +1,8 @@
 name: Dockercross Cross-Compilation Tests
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ main, master, v* ]
-  pull_request:
     branches: [ main, master, v* ]
 
 concurrency:
@@ -42,4 +41,4 @@ jobs:
     - name: Test ${{ matrix.target }}
       run: |
         echo "Testing dockercross target: ${{ matrix.target }}"
-        docker run -i --rm -v "$PWD:/src" dockcross/${{ matrix.target }} bash -c 'cd /src && make clean && make' 
+        docker run -i --rm -v "$PWD:/src" dockcross/${{ matrix.target }} bash -c 'cd /src && make clean && make'

--- a/.github/workflows/gcc-tests.yml
+++ b/.github/workflows/gcc-tests.yml
@@ -1,9 +1,8 @@
 name: GCC Version Tests
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ main, master, v* ]
-  pull_request:
     branches: [ main, master, v* ]
 
 concurrency:
@@ -31,4 +30,4 @@ jobs:
     - name: Test GCC ${{ matrix.gcc_version }} on ${{ matrix.runner }}
       run: |
         echo "Testing GCC ${{ matrix.gcc_version }} on ${{ matrix.runner }}"
-        docker run -i -v "$PWD:/src" --rm gcc:${{ matrix.gcc_version }} bash -c "cd /src && make clean && make && output/eatmemory 100M -t 0" 
+        docker run -i -v "$PWD:/src" --rm gcc:${{ matrix.gcc_version }} bash -c "cd /src && make clean && make && output/eatmemory 100M -t 0"

--- a/.github/workflows/simple-run-test.yml
+++ b/.github/workflows/simple-run-test.yml
@@ -1,9 +1,8 @@
 name: Simple Run Test
 
 on:
+  workflow_dispatch:
   push:
-    branches: [main, master, v*]
-  pull_request:
     branches: [main, master, v*]
 
 concurrency:

--- a/src/eatmemory.dragonfly.c
+++ b/src/eatmemory.dragonfly.c
@@ -1,0 +1,74 @@
+#include "eatmemory.h"
+#ifdef SYSMEM_MODE_DRAGONFLY
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <string.h>
+
+static size_t bytes_to_size_clamped(uint64_t bytes) {
+    return bytes > SIZE_MAX ? SIZE_MAX : (size_t)bytes;
+}
+
+static size_t pages_to_bytes_clamped(uint64_t pages, uint64_t page_size) {
+    if (pages != 0 && page_size > UINT64_MAX / pages) {
+        return SIZE_MAX;
+    }
+
+    return bytes_to_size_clamped(pages * page_size);
+}
+
+static bool read_sysctl_uint64(const char* name, uint64_t* value) {
+    unsigned char data[sizeof(uint64_t)] = {0};
+    size_t data_size = sizeof(data);
+
+    if (sysctlbyname(name, data, &data_size, NULL, 0) != 0) {
+        return false;
+    }
+
+    if (data_size == sizeof(uint64_t)) {
+        uint64_t result;
+        memcpy(&result, data, sizeof(result));
+        *value = result;
+        return true;
+    }
+
+    if (data_size == sizeof(unsigned int)) {
+        unsigned int result;
+        memcpy(&result, data, sizeof(result));
+        *value = result;
+        return true;
+    }
+
+    if (data_size == sizeof(int)) {
+        int result;
+        memcpy(&result, data, sizeof(result));
+        if (result < 0) {
+            return false;
+        }
+
+        *value = (uint64_t)result;
+        return true;
+    }
+
+    return false;
+}
+
+void get_system_memory_stats(struct system_memory_stats* stats) {
+    uint64_t total_bytes;
+    uint64_t page_size;
+    uint64_t free_pages;
+
+    stats->supported = false;
+    stats->total = 0;
+    stats->free = 0;
+
+    if (read_sysctl_uint64("hw.physmem", &total_bytes) &&
+        read_sysctl_uint64("hw.pagesize", &page_size) &&
+        read_sysctl_uint64("vm.stats.vm.v_free_count", &free_pages) &&
+        total_bytes > 0 && page_size > 0) {
+        stats->total = bytes_to_size_clamped(total_bytes);
+        stats->free = pages_to_bytes_clamped(free_pages, page_size);
+        stats->supported = true;
+    }
+}
+
+#endif

--- a/src/eatmemory.freebsd.c
+++ b/src/eatmemory.freebsd.c
@@ -1,0 +1,74 @@
+#include "eatmemory.h"
+#ifdef SYSMEM_MODE_FREEBSD
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <string.h>
+
+static size_t bytes_to_size_clamped(uint64_t bytes) {
+    return bytes > SIZE_MAX ? SIZE_MAX : (size_t)bytes;
+}
+
+static size_t pages_to_bytes_clamped(uint64_t pages, uint64_t page_size) {
+    if (pages != 0 && page_size > UINT64_MAX / pages) {
+        return SIZE_MAX;
+    }
+
+    return bytes_to_size_clamped(pages * page_size);
+}
+
+static bool read_sysctl_uint64(const char* name, uint64_t* value) {
+    unsigned char data[sizeof(uint64_t)] = {0};
+    size_t data_size = sizeof(data);
+
+    if (sysctlbyname(name, data, &data_size, NULL, 0) != 0) {
+        return false;
+    }
+
+    if (data_size == sizeof(uint64_t)) {
+        uint64_t result;
+        memcpy(&result, data, sizeof(result));
+        *value = result;
+        return true;
+    }
+
+    if (data_size == sizeof(unsigned int)) {
+        unsigned int result;
+        memcpy(&result, data, sizeof(result));
+        *value = result;
+        return true;
+    }
+
+    if (data_size == sizeof(int)) {
+        int result;
+        memcpy(&result, data, sizeof(result));
+        if (result < 0) {
+            return false;
+        }
+
+        *value = (uint64_t)result;
+        return true;
+    }
+
+    return false;
+}
+
+void get_system_memory_stats(struct system_memory_stats* stats) {
+    uint64_t total_bytes;
+    uint64_t page_size;
+    uint64_t free_pages;
+
+    stats->supported = false;
+    stats->total = 0;
+    stats->free = 0;
+
+    if (read_sysctl_uint64("hw.physmem", &total_bytes) &&
+        read_sysctl_uint64("hw.pagesize", &page_size) &&
+        read_sysctl_uint64("vm.stats.vm.v_free_count", &free_pages) &&
+        total_bytes > 0 && page_size > 0) {
+        stats->total = bytes_to_size_clamped(total_bytes);
+        stats->free = pages_to_bytes_clamped(free_pages, page_size);
+        stats->supported = true;
+    }
+}
+
+#endif

--- a/src/eatmemory.h
+++ b/src/eatmemory.h
@@ -18,6 +18,14 @@
     #define SYSMEM_MODE_AIX
 #elif defined(__sun)
     #define SYSMEM_MODE_SOLARIS
+#elif defined(__DragonFly__)
+    #define SYSMEM_MODE_DRAGONFLY
+#elif defined(__FreeBSD__)
+    #define SYSMEM_MODE_FREEBSD
+#elif defined(__OpenBSD__)
+    #define SYSMEM_MODE_OPENBSD
+#elif defined(__NetBSD__)
+    #define SYSMEM_MODE_NETBSD
 #elif defined(__linux__)
     #define SYSMEM_MODE_LINUX
 #else

--- a/src/eatmemory.netbsd.c
+++ b/src/eatmemory.netbsd.c
@@ -1,0 +1,38 @@
+#include "eatmemory.h"
+#ifdef SYSMEM_MODE_NETBSD
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <uvm/uvm_param.h>
+#include <uvm/uvm_extern.h>
+
+static size_t pages_to_bytes_clamped(int64_t pages, int64_t page_size) {
+    uint64_t unsigned_pages = (uint64_t)pages;
+    uint64_t unsigned_page_size = (uint64_t)page_size;
+
+    if (unsigned_pages != 0 && unsigned_page_size > UINT64_MAX / unsigned_pages) {
+        return SIZE_MAX;
+    }
+
+    uint64_t bytes = unsigned_pages * unsigned_page_size;
+    return bytes > SIZE_MAX ? SIZE_MAX : (size_t)bytes;
+}
+
+void get_system_memory_stats(struct system_memory_stats* stats) {
+    int mib[2] = {CTL_VM, VM_UVMEXP2};
+    struct uvmexp_sysctl uvm;
+    size_t uvm_size = sizeof(uvm);
+
+    stats->supported = false;
+    stats->total = 0;
+    stats->free = 0;
+
+    if (sysctl(mib, 2, &uvm, &uvm_size, NULL, 0) == 0 &&
+        uvm_size == sizeof(uvm) &&
+        uvm.npages > 0 && uvm.pagesize > 0 && uvm.free >= 0) {
+        stats->total = pages_to_bytes_clamped(uvm.npages, uvm.pagesize);
+        stats->free = pages_to_bytes_clamped(uvm.free, uvm.pagesize);
+        stats->supported = true;
+    }
+}
+
+#endif

--- a/src/eatmemory.openbsd.c
+++ b/src/eatmemory.openbsd.c
@@ -1,0 +1,36 @@
+#include "eatmemory.h"
+#ifdef SYSMEM_MODE_OPENBSD
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+static size_t pages_to_bytes_clamped(int pages, int page_size) {
+    uint64_t unsigned_pages = (uint64_t)pages;
+    uint64_t unsigned_page_size = (uint64_t)page_size;
+
+    if (unsigned_pages != 0 && unsigned_page_size > UINT64_MAX / unsigned_pages) {
+        return SIZE_MAX;
+    }
+
+    uint64_t bytes = unsigned_pages * unsigned_page_size;
+    return bytes > SIZE_MAX ? SIZE_MAX : (size_t)bytes;
+}
+
+void get_system_memory_stats(struct system_memory_stats* stats) {
+    int mib[2] = {CTL_VM, VM_UVMEXP};
+    struct uvmexp uvm;
+    size_t uvm_size = sizeof(uvm);
+
+    stats->supported = false;
+    stats->total = 0;
+    stats->free = 0;
+
+    if (sysctl(mib, 2, &uvm, &uvm_size, NULL, 0) == 0 &&
+        uvm_size == sizeof(uvm) &&
+        uvm.npages > 0 && uvm.pagesize > 0 && uvm.free >= 0) {
+        stats->total = pages_to_bytes_clamped(uvm.npages, uvm.pagesize);
+        stats->free = pages_to_bytes_clamped(uvm.free, uvm.pagesize);
+        stats->supported = true;
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

- Add memory stats backends for FreeBSD, OpenBSD, NetBSD, and DragonFly BSD.
- Detect each BSD target in eatmemory.h and keep each backend guarded like the existing platform files.
- Extend cfarm SSH CI to cover the BSD hosts and make the remote tar/shell paths matrix-driven for non-AIX/Solaris systems.

## Compile farm hosts

- FreeBSD: cfarm430.cfarm.net
- OpenBSD: cfarm429.cfarm.net
- NetBSD: cfarm428.cfarm.net
- DragonFly BSD: cfarm152.cfarm.net

cfarm429 is used for OpenBSD instead of cfarm220 because cfarm220 has hundreds of GB of RAM but a low default per-process data limit, making the 1% smoke test try to allocate several GB.

## Validation

- MAKE=make bash test/simple.test.sh
- ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/cfarm-ssh-tests.yml\"); puts \"yaml ok\""
- FreeBSD smoke test on cfarm430.cfarm.net
- OpenBSD smoke test on cfarm429.cfarm.net
- NetBSD smoke test on cfarm428.cfarm.net
- DragonFly BSD smoke test on cfarm152.cfarm.net

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added system memory stats support for DragonFlyBSD, FreeBSD, OpenBSD, and NetBSD.

* **Chores**
  * CI compile-farm workflow enhanced to allow per-host port/tar/kex configuration, respect configured PATH for remote commands, stream-and-extract sources on the remote host, add a FreeBSD SSH debug step, and improve remote workspace preparation and cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/julman99/eatmemory/pull/23)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->