### PR TITLE
Refactor platform memory backend selection

### DIFF
--- a/.github/workflows/simple-run-test.yml
+++ b/.github/workflows/simple-run-test.yml
@@ -23,12 +23,17 @@ jobs:
           - { os: ubuntu-24.04-arm }
           - { os: ubuntu-22.04-arm }
           - { os: macos-latest }
-          - { os: windows-latest }
-          - { os: windows-11-arm }
+          - { os: windows-latest, windows_env: msys2 }
+          - { os: windows-latest, windows_env: cygwin }
+          - { os: windows-11-arm, windows_env: msys2 }
 
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Use LF line endings for Cygwin
+        if: runner.os == 'Windows' && matrix.windows_env == 'cygwin'
+        run: git config --global core.autocrlf input
+
       - name: Checkout code
         uses: actions/checkout@v6
 
@@ -45,7 +50,7 @@ jobs:
           which make
 
       - name: Setup MSYS2 (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.windows_env == 'msys2'
         uses: msys2/setup-msys2@v2
         with:
           msystem: UCRT64
@@ -56,13 +61,26 @@ jobs:
             make
             bash
 
+      - name: Setup Cygwin (Windows)
+        if: runner.os == 'Windows' && matrix.windows_env == 'cygwin'
+        uses: cygwin/cygwin-install-action@v6
+        with:
+          packages: |
+            gcc-core
+            git
+            make
+
       - name: Run simple test (Unix)
         if: runner.os != 'Windows'
         env:
           EXTRA_CFLAGS: ${{ matrix.extra_cflags }}
         run: bash test/simple.test.sh
 
-      - name: Run simple test (Windows)
-        if: runner.os == 'Windows'
+      - name: Run simple test (MSYS2)
+        if: runner.os == 'Windows' && matrix.windows_env == 'msys2'
         shell: msys2 {0}
+        run: bash test/simple.test.sh
+
+      - name: Run simple test (Cygwin)
+        if: runner.os == 'Windows' && matrix.windows_env == 'cygwin'
         run: bash test/simple.test.sh

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ ifneq ($(findstring __APPLE__,$(CC_TARGET_MACROS)),)
     CC_TARGET_OS := Darwin
 else ifneq ($(findstring _WIN32,$(CC_TARGET_MACROS)),)
     CC_TARGET_OS := Windows
+else ifneq ($(findstring __CYGWIN__,$(CC_TARGET_MACROS)),)
+    CC_TARGET_OS := CYGWIN
 else ifneq ($(findstring _AIX,$(CC_TARGET_MACROS)),)
     CC_TARGET_OS := AIX
 else ifneq ($(findstring __sun,$(CC_TARGET_MACROS)),)
@@ -62,7 +64,7 @@ ifndef SYS_SRC
     else ifeq ($(SYS_OS),Darwin)
         SYS_SRC := $(SRC_DIR)/eatmemory.apple.c
         SYS_BACKEND := Darwin
-    else ifneq ($(filter Windows MINGW% MSYS%,$(SYS_OS)),)
+    else ifneq ($(filter Windows MINGW% MSYS% CYGWIN%,$(SYS_OS)),)
         SYS_SRC := $(SRC_DIR)/eatmemory.windows.c
         SYS_BACKEND := Windows
     else
@@ -125,7 +127,7 @@ help:
 	@echo "  clean         - Remove generated files"
 	@echo "  help          - Display this help message"
 	@echo "Variables:"
-	@echo "  SYS_OS        - Override backend auto-detection (Linux, Darwin, AIX, SunOS, Windows, Unknown)"
+	@echo "  SYS_OS        - Override backend auto-detection (Linux, Darwin, AIX, SunOS, Windows, CYGWIN*, Unknown)"
 	@echo "  SYS_SRC       - Override the backend source file directly"
 
 .PHONY: all install clean help

--- a/Makefile
+++ b/Makefile
@@ -54,18 +54,29 @@ COMMON_SRC := $(filter-out $(BACKEND_SRC),$(wildcard $(SRC_DIR)/*.c))
 ifndef SYS_SRC
     ifeq ($(SYS_OS),SunOS)
         SYS_SRC := $(SRC_DIR)/eatmemory.solaris.c
+        SYS_BACKEND := SunOS
     else ifeq ($(SYS_OS),AIX)
         SYS_SRC := $(SRC_DIR)/eatmemory.aix.c
+        SYS_BACKEND := AIX
     else ifeq ($(SYS_OS),Linux)
         SYS_SRC := $(SRC_DIR)/eatmemory.linux.c
+        SYS_BACKEND := Linux
     else ifeq ($(SYS_OS),Darwin)
         SYS_SRC := $(SRC_DIR)/eatmemory.apple.c
+        SYS_BACKEND := Darwin
     else ifneq ($(filter Windows MINGW% MSYS%,$(SYS_OS)),)
         SYS_SRC := $(SRC_DIR)/eatmemory.windows.c
+        SYS_BACKEND := Windows
     else
         SYS_SRC := $(SRC_DIR)/eatmemory.unknown.c
+        SYS_BACKEND := Unkown OS
     endif
 endif
+SYS_BACKEND ?= $(patsubst eatmemory.%.c,%,$(notdir $(SYS_SRC)))
+ifeq ($(SYS_BACKEND),unknown)
+    SYS_BACKEND := Unkown OS
+endif
+CFLAGS += -DSYSMEM_BACKEND='"$(SYS_BACKEND)"'
 
 ifeq ($(notdir $(SYS_SRC)),eatmemory.aix.c)
     LDFLAGS += -lperfstat

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 CC ?= gcc
 
+SRC_DIR := src
+INCLUDE_DIR := include
+OUTPUT_DIR := output
+
 # Version string is derived from the most recent v* tag plus the number of
 # commits since, the abbreviated commit hash, and a -dirty suffix if the
 # working tree has uncommitted changes. The leading 'v' is stripped so the
@@ -17,21 +21,65 @@ EXTRA_CFLAGS ?=
 CFLAGS := -Wall -Wextra -std=c99 -O2 -g $(EXTRA_CFLAGS) -DVERSION='"$(VERSION)"'
 LDFLAGS :=
 
+# Prefer compiler target macros so cross-compilation selects the target
+# backend instead of the build host. If probing fails, fall back to uname; if
+# probing succeeds without a known OS macro, use the unknown backend.
+CC_TARGET_MACROS := $(shell $(CC) -dM -E -x c /dev/null 2>/dev/null)
+ifneq ($(findstring __APPLE__,$(CC_TARGET_MACROS)),)
+    CC_TARGET_OS := Darwin
+else ifneq ($(findstring _WIN32,$(CC_TARGET_MACROS)),)
+    CC_TARGET_OS := Windows
+else ifneq ($(findstring _WIN64,$(CC_TARGET_MACROS)),)
+    CC_TARGET_OS := Windows
+else ifneq ($(findstring _AIX,$(CC_TARGET_MACROS)),)
+    CC_TARGET_OS := AIX
+else ifneq ($(findstring __sun,$(CC_TARGET_MACROS)),)
+    CC_TARGET_OS := SunOS
+else ifneq ($(findstring __linux__,$(CC_TARGET_MACROS)),)
+    CC_TARGET_OS := Linux
+else ifneq ($(strip $(CC_TARGET_MACROS)),)
+    CC_TARGET_OS := Unknown
+endif
+ifneq ($(findstring mingw,$(CC)),)
+    CC_NAME_OS := Windows
+else ifneq ($(findstring MINGW,$(CC)),)
+    CC_NAME_OS := Windows
+endif
 UNAME_S := $(shell uname -s 2>/dev/null)
-ifeq ($(UNAME_S),AIX)
+SYS_OS ?= $(or $(filter-out Unknown,$(CC_TARGET_OS)),$(CC_NAME_OS),$(CC_TARGET_OS),$(UNAME_S),Unknown)
+
+BACKEND_SRC := $(wildcard $(SRC_DIR)/eatmemory.*.c)
+COMMON_SRC := $(filter-out $(BACKEND_SRC),$(wildcard $(SRC_DIR)/*.c))
+
+ifndef SYS_SRC
+    ifeq ($(SYS_OS),SunOS)
+        SYS_SRC := $(SRC_DIR)/eatmemory.solaris.c
+    else ifeq ($(SYS_OS),AIX)
+        SYS_SRC := $(SRC_DIR)/eatmemory.aix.c
+    else ifeq ($(SYS_OS),Linux)
+        SYS_SRC := $(SRC_DIR)/eatmemory.linux.c
+    else ifeq ($(SYS_OS),Darwin)
+        SYS_SRC := $(SRC_DIR)/eatmemory.apple.c
+    else ifneq ($(filter Windows MINGW% MSYS%,$(SYS_OS)),)
+        SYS_SRC := $(SRC_DIR)/eatmemory.windows.c
+    else
+        SYS_SRC := $(SRC_DIR)/eatmemory.unknown.c
+    endif
+endif
+
+ifeq ($(notdir $(SYS_SRC)),eatmemory.aix.c)
     LDFLAGS += -lperfstat
 endif
 
-ifneq ($(findstring mingw,$(CC)),)
+ifneq ($(filter eatmemory.windows.c,$(notdir $(SYS_SRC))),)
+    EXE_SUFFIX := .exe
+else ifeq ($(CC_NAME_OS),Windows)
     EXE_SUFFIX := .exe
 else
     EXE_SUFFIX :=
 endif
 
-SRC_DIR := src
-INCLUDE_DIR := include
-OUTPUT_DIR := output
-SRC := $(wildcard $(SRC_DIR)/*.c)
+SRC := $(COMMON_SRC) $(SYS_SRC)
 OBJ := $(patsubst $(SRC_DIR)/%.c,$(OUTPUT_DIR)/%.o,$(SRC))
 EXE := $(OUTPUT_DIR)/eatmemory$(EXE_SUFFIX)
 
@@ -67,9 +115,8 @@ help:
 	@echo "  install       - Install the executable to PREFIX/bin"
 	@echo "  clean         - Remove generated files"
 	@echo "  help          - Display this help message"
+	@echo "Variables:"
+	@echo "  SYS_OS        - Override backend auto-detection (Linux, Darwin, AIX, SunOS, Windows, Unknown)"
+	@echo "  SYS_SRC       - Override the backend source file directly"
 
 .PHONY: all install clean help
-
-
-
-

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,6 @@ ifneq ($(findstring __APPLE__,$(CC_TARGET_MACROS)),)
     CC_TARGET_OS := Darwin
 else ifneq ($(findstring _WIN32,$(CC_TARGET_MACROS)),)
     CC_TARGET_OS := Windows
-else ifneq ($(findstring _WIN64,$(CC_TARGET_MACROS)),)
-    CC_TARGET_OS := Windows
 else ifneq ($(findstring _AIX,$(CC_TARGET_MACROS)),)
     CC_TARGET_OS := AIX
 else ifneq ($(findstring __sun,$(CC_TARGET_MACROS)),)

--- a/src/eatmemory.aix.c
+++ b/src/eatmemory.aix.c
@@ -1,5 +1,4 @@
 #include "eatmemory.h"
-#ifdef SYSMEM_MODE_AIX
 #include <libperfstat.h>
 
 /* libperfstat always reports real_total/real_free in 4 KB units regardless
@@ -30,5 +29,3 @@ void get_system_memory_stats(struct system_memory_stats* stats) {
     stats->free = pages_4k_to_bytes_clamped(memory.real_free);
     stats->supported = true;
 }
-
-#endif

--- a/src/eatmemory.apple.c
+++ b/src/eatmemory.apple.c
@@ -1,6 +1,7 @@
 #include "eatmemory.h"
 #include <mach/mach_host.h>
 #include <mach/mach_init.h>
+#include <mach/mach_port.h>
 
 void get_system_memory_stats(struct system_memory_stats* stats) {
     vm_size_t page_size;
@@ -9,6 +10,7 @@ void get_system_memory_stats(struct system_memory_stats* stats) {
 
     if (host_page_size(host_port, &page_size) != KERN_SUCCESS) {
         stats->supported = false;
+        mach_port_deallocate(mach_task_self(), host_port);
         return;
     }
     vm_statistics_data_t vm_stat;
@@ -16,8 +18,10 @@ void get_system_memory_stats(struct system_memory_stats* stats) {
     count = sizeof(vm_stat) / sizeof(natural_t);
     if (host_statistics(host_port, HOST_VM_INFO, (host_info_t)&vm_stat, &count) != KERN_SUCCESS) {
         stats->supported = false;
+        mach_port_deallocate(mach_task_self(), host_port);
         return;
     }
+    mach_port_deallocate(mach_task_self(), host_port);
     stats->supported = true;
 
     natural_t pages = vm_stat.wire_count + vm_stat.active_count + vm_stat.inactive_count + vm_stat.free_count +

--- a/src/eatmemory.apple.c
+++ b/src/eatmemory.apple.c
@@ -1,32 +1,30 @@
 #include "eatmemory.h"
-#ifdef SYSMEM_MODE_APPLE
-    #include <mach/mach_host.h>
-    #include <mach/mach_init.h>
+#include <mach/mach_host.h>
+#include <mach/mach_init.h>
 
-    void get_system_memory_stats(struct system_memory_stats* stats) {
-        vm_size_t page_size;
-        mach_port_t host_port = mach_host_self();
-        mach_msg_type_number_t count;
+void get_system_memory_stats(struct system_memory_stats* stats) {
+    vm_size_t page_size;
+    mach_port_t host_port = mach_host_self();
+    mach_msg_type_number_t count;
 
-        if (host_page_size(host_port, &page_size) != KERN_SUCCESS) {
-            stats->supported = false;
-            return;
-        }
-        vm_statistics_data_t vm_stat;
-
-        count = sizeof(vm_stat) / sizeof(natural_t);
-        if (host_statistics(host_port, HOST_VM_INFO, (host_info_t)&vm_stat, &count) != KERN_SUCCESS) {
-            stats->supported = false;
-            return;
-        }
-        stats->supported = true;
-
-        natural_t pages = vm_stat.wire_count + vm_stat.active_count + vm_stat.inactive_count + vm_stat.free_count +
-                          vm_stat.speculative_count + vm_stat.purgeable_count;
-
-        stats->total = (size_t)pages * (size_t)page_size;
-
-        natural_t free_memory = vm_stat.free_count + vm_stat.inactive_count;
-        stats->free = (size_t)free_memory * (size_t)page_size;
+    if (host_page_size(host_port, &page_size) != KERN_SUCCESS) {
+        stats->supported = false;
+        return;
     }
-#endif
+    vm_statistics_data_t vm_stat;
+
+    count = sizeof(vm_stat) / sizeof(natural_t);
+    if (host_statistics(host_port, HOST_VM_INFO, (host_info_t)&vm_stat, &count) != KERN_SUCCESS) {
+        stats->supported = false;
+        return;
+    }
+    stats->supported = true;
+
+    natural_t pages = vm_stat.wire_count + vm_stat.active_count + vm_stat.inactive_count + vm_stat.free_count +
+                      vm_stat.speculative_count + vm_stat.purgeable_count;
+
+    stats->total = (size_t)pages * (size_t)page_size;
+
+    natural_t free_memory = vm_stat.free_count + vm_stat.inactive_count;
+    stats->free = (size_t)free_memory * (size_t)page_size;
+}

--- a/src/eatmemory.c
+++ b/src/eatmemory.c
@@ -78,10 +78,6 @@ size_t string_to_bytes(char * str, eatmemory_error* error) {
         } else if (unit == 'G') {
             numerator = TO_GB;
         } else if (unit == '%') {
-#ifdef SYSMEM_MODE_UNKNOWN
-            *error = EM_ERROR_PARSE_INVALID_UNIT;
-            return 0;
-#else
             struct system_memory_stats memory_stats;
             get_system_memory_stats(&memory_stats);
             if (!memory_stats.supported) {
@@ -90,7 +86,6 @@ size_t string_to_bytes(char * str, eatmemory_error* error) {
             }
             numerator = memory_stats.free;
             denominator = 100;
-#endif
         } else {
             *error = EM_ERROR_PARSE_INVALID_UNIT;
             return 0;

--- a/src/eatmemory.h
+++ b/src/eatmemory.h
@@ -10,21 +10,6 @@
 #define TO_MB (1024UL * TO_KB)
 #define TO_GB (1024UL * TO_MB)
 
-#ifdef __APPLE__
-    #define SYSMEM_MODE_APPLE
-#elif defined(_WIN32) || defined(_WIN64)
-    #define SYSMEM_MODE_WINDOWS
-#elif defined(_AIX)
-    #define SYSMEM_MODE_AIX
-#elif defined(__sun)
-    #define SYSMEM_MODE_SOLARIS
-#elif defined(__linux__)
-    #define SYSMEM_MODE_LINUX
-#else
-    #define SYSMEM_MODE_UNKNOWN
-#endif
-
-
 struct system_memory_stats {
     bool supported;
     size_t total;

--- a/src/eatmemory.linux.c
+++ b/src/eatmemory.linux.c
@@ -8,6 +8,8 @@ static size_t pages_to_bytes_clamped(long pages, long page_size) {
 
 void get_system_memory_stats(struct system_memory_stats* stats) {
     stats->supported = false;
+    stats->total = 0;
+    stats->free = 0;
 
 #if defined(_SC_PHYS_PAGES) && defined(_SC_AVPHYS_PAGES) && defined(_SC_PAGE_SIZE)
     long pages = sysconf(_SC_PHYS_PAGES);

--- a/src/eatmemory.linux.c
+++ b/src/eatmemory.linux.c
@@ -1,5 +1,4 @@
 #include "eatmemory.h"
-#ifdef SYSMEM_MODE_LINUX
 #include <unistd.h>
 
 static size_t pages_to_bytes_clamped(long pages, long page_size) {
@@ -22,5 +21,3 @@ void get_system_memory_stats(struct system_memory_stats* stats) {
     }
 #endif
 }
-
-#endif

--- a/src/eatmemory.solaris.c
+++ b/src/eatmemory.solaris.c
@@ -1,5 +1,4 @@
 #include "eatmemory.h"
-#ifdef SYSMEM_MODE_SOLARIS
 #include <unistd.h>
 
 static size_t pages_to_bytes_clamped(long pages, long page_size) {
@@ -24,5 +23,3 @@ void get_system_memory_stats(struct system_memory_stats* stats) {
     }
 #endif
 }
-
-#endif

--- a/src/eatmemory.unknown.c
+++ b/src/eatmemory.unknown.c
@@ -1,10 +1,7 @@
 #include "eatmemory.h"
-#ifdef SYSMEM_MODE_UNKNOWN
 
 void get_system_memory_stats(struct system_memory_stats* stats) {
     stats->supported = false;
     stats->total = 0;
     stats->free = 0;
 }
-
-#endif

--- a/src/eatmemory.windows.c
+++ b/src/eatmemory.windows.c
@@ -1,21 +1,19 @@
 #include "eatmemory.h"
-#ifdef SYSMEM_MODE_WINDOWS
-    #include <windows.h>
+#include <windows.h>
 
-    void get_system_memory_stats(struct system_memory_stats* stats) {
-        MEMORYSTATUSEX memstat;
-        memstat.dwLength = sizeof(memstat);
+void get_system_memory_stats(struct system_memory_stats* stats) {
+    MEMORYSTATUSEX memstat;
+    memstat.dwLength = sizeof(memstat);
 
-        if (GlobalMemoryStatusEx(&memstat)) {
-            stats->supported = true;
-            // ullTotalPhys / ullAvailPhys are DWORDLONG (64-bit). On 32-bit
-            // Windows with >4 GB RAM, a direct cast to size_t (32-bit there)
-            // silently truncates and reports nonsense memory amounts. Clamp
-            // to SIZE_MAX so the caller at least sees a bounded value.
-            stats->total = (memstat.ullTotalPhys > SIZE_MAX) ? SIZE_MAX : (size_t)memstat.ullTotalPhys;
-            stats->free  = (memstat.ullAvailPhys > SIZE_MAX) ? SIZE_MAX : (size_t)memstat.ullAvailPhys;
-        } else {
-            stats->supported = false;
-        }
+    if (GlobalMemoryStatusEx(&memstat)) {
+        stats->supported = true;
+        // ullTotalPhys / ullAvailPhys are DWORDLONG (64-bit). On 32-bit
+        // Windows with >4 GB RAM, a direct cast to size_t (32-bit there)
+        // silently truncates and reports nonsense memory amounts. Clamp
+        // to SIZE_MAX so the caller at least sees a bounded value.
+        stats->total = (memstat.ullTotalPhys > SIZE_MAX) ? SIZE_MAX : (size_t)memstat.ullTotalPhys;
+        stats->free  = (memstat.ullAvailPhys > SIZE_MAX) ? SIZE_MAX : (size_t)memstat.ullAvailPhys;
+    } else {
+        stats->supported = false;
     }
-#endif
+}

--- a/src/main.c
+++ b/src/main.c
@@ -35,9 +35,11 @@ void print_help() {
     printf("#                # Bytes      example: 1024\n");
     printf("#M               # Megabytes  example: 15M\n");
     printf("#G               # Gigabytes  example: 2G\n");
-#ifndef SYSMEM_MODE_UNKNOWN
-    printf("#%%               # Percent    example: 50%%\n");
-#endif
+    struct system_memory_stats memory_stats;
+    get_system_memory_stats(&memory_stats);
+    if (memory_stats.supported) {
+        printf("#%%               # Percent    example: 50%%\n");
+    }
     printf("\n");
     printf("Options:\n");
     printf("-t <seconds>     Exit after specified number of seconds.\n");
@@ -119,4 +121,3 @@ int main(int argc, char *argv[]){
     }
     digest(eaten);
 }
-

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,10 @@
 #include <unistd.h>
 #include "errors.h"
 
+#ifndef SYSMEM_BACKEND
+#define SYSMEM_BACKEND "Unkown OS"
+#endif
+
 ArgParser* configure_cmd() {
     ArgParser* parser = ap_new_parser();
     ap_add_flag(parser, "help h ?");
@@ -29,7 +33,7 @@ ArgParser* configure_cmd() {
 }
 
 void print_help() {
-    printf("eatmemory %s - %s\n\n", VERSION, "https://github.com/julman99/eatmemory");
+    printf("eatmemory %s - %s - %s\n\n", VERSION, "https://github.com/julman99/eatmemory", SYSMEM_BACKEND);
     printf("Usage: eatmemory [-t <seconds>] <size>\n");
     printf("Size can be specified in megabytes or gigabytes in the following way:\n");
     printf("#                # Bytes      example: 1024\n");

--- a/test/simple.test.sh
+++ b/test/simple.test.sh
@@ -69,11 +69,16 @@ expected_backend="$(detect_expected_backend)"
 help_first_line="$(./output/eatmemory -? | sed -n '1p')"
 expected_help_suffix=" - https://github.com/julman99/eatmemory - ${expected_backend}"
 
+echo ""
+echo "Backend detection check:"
+echo "Expected backend: $expected_backend"
+echo "Help first line:  $help_first_line"
 if [[ "$help_first_line" != *"$expected_help_suffix" ]]; then
     echo "ERROR: expected help output to include backend '$expected_backend'"
     echo "Actual first help line: $help_first_line"
     exit 1
 fi
+echo "✓ Backend detection confirmed"
 
 # Helper function to run a test case that should succeed (exit 0).
 run_test() {

--- a/test/simple.test.sh
+++ b/test/simple.test.sh
@@ -15,6 +15,33 @@ readonly UNDER_1MB_BYTES=$((ONE_MB_BYTES - 1))          # 1048575
 readonly OVER_1MB_BYTES=$((ONE_MB_BYTES + 1))           # 1048577
 readonly LARGE_TEST_SIZE="100M"                         # Comfortably above 1 MB
 
+detect_expected_backend() {
+    local uname_s
+    uname_s="$(uname -s 2>/dev/null || true)"
+
+    case "$uname_s" in
+        Linux*)
+            echo "Linux"
+            ;;
+        Darwin*)
+            echo "Darwin"
+            ;;
+        AIX*)
+            echo "AIX"
+            ;;
+        SunOS*)
+            echo "SunOS"
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            echo "Windows"
+            ;;
+        *)
+            echo "ERROR: unable to detect expected backend from uname -s: $uname_s" >&2
+            return 1
+            ;;
+    esac
+}
+
 echo "eatmemory sanity tests - 1 MB boundary coverage plus error paths"
 echo "================================================================="
 
@@ -35,6 +62,16 @@ echo "Building eatmemory..."
 echo "Checking if eatmemory executable exists..."
 if [[ ! -f "output/eatmemory" ]]; then
     echo "ERROR: eatmemory executable not found at output/eatmemory"
+    exit 1
+fi
+
+expected_backend="$(detect_expected_backend)"
+help_first_line="$(./output/eatmemory -? | sed -n '1p')"
+expected_help_suffix=" - https://github.com/julman99/eatmemory - ${expected_backend}"
+
+if [[ "$help_first_line" != *"$expected_help_suffix" ]]; then
+    echo "ERROR: expected help output to include backend '$expected_backend'"
+    echo "Actual first help line: $help_first_line"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- select one platform memory backend in the Makefile instead of compiling every backend
- derive common sources by filtering backend-shaped files from src/*.c
- remove redundant SYSMEM_MODE source guards and rely on backend support at runtime for percent handling/help text

Fixes #22

## Testing
- make -B
- test/simple.test.sh
- make -B -n SYS_OS=Linux
- make -B -n SYS_OS=Windows
- make -B -n SYS_OS=AIX
- make -B -n SYS_OS=Unknown
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured build system to enable automatic platform detection via compiler introspection.
  * Migrated platform-specific implementations from compile-time conditional selection to runtime capability detection.
  * Streamlined cross-platform support by consolidating platform detection logic in the build configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/julman99/eatmemory/pull/24)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->