### PR TITLE
Clarify interactive terminal checks

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -81,6 +81,14 @@ void print_and_exit_if_error(eatmemory_error if_error, char * error_message, eat
     }
 }
 
+static bool output_is_terminal(void) {
+    return isatty(fileno(stdout));
+}
+
+static bool can_prompt_for_enter(void) {
+    return isatty(fileno(stdin)) && output_is_terminal();
+}
+
 struct terminal_progress {
     bool active;
     enum eatmemory_progress_stage stage;
@@ -177,7 +185,7 @@ int main(int argc, char *argv[]){
 
     ap_free(parser);
 
-    bool show_progress = isatty(fileno(stdout));
+    bool show_progress = output_is_terminal();
 
     print_memory_summary(&backend);
     printf("\n");
@@ -204,7 +212,7 @@ int main(int argc, char *argv[]){
     }
 
     if(eaten.chunks){
-        if(timeout < 0 && isatty(fileno(stdin))) {
+        if(timeout < 0 && can_prompt_for_enter()) {
             printf("Done, press ENTER to free the memory\n");
             getchar();
         } else if (timeout >= 0) {


### PR DESCRIPTION
## Summary
- add helpers for output-terminal and ENTER-prompt interactivity checks
- keep progress tied to stdout being a terminal
- require both stdin and stdout to be terminals before prompting for ENTER

## Testing
- git diff --check
- make clean
- bash test/ci/all.test.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved terminal detection for progress display and interactive prompts. The program now more accurately determines when it can safely display progress indicators and prompt for user input, requiring both input and output to be connected to a terminal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/julman99/eatmemory/pull/28)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->